### PR TITLE
appdata: add vcs-browser and translate url support

### DIFF
--- a/data/io.github.diegopvlk.Dosage.appdata.xml.in
+++ b/data/io.github.diegopvlk.Dosage.appdata.xml.in
@@ -71,4 +71,6 @@
 	<update_contact>diego.pvlk@gmail.com</update_contact>
 	<url type="homepage">https://github.com/diegopvlk/Dosage</url>
 	<url type="bugtracker">https://github.com/diegopvlk/Dosage/issues</url>
+	<url type="vcs-browser">https://github.com/diegopvlk/Dosage</url>
+	<url type="translate">https://hosted.weblate.org/translate/dosage</url>
 </component>


### PR DESCRIPTION
These links are visible on Flathub and GNOME Software.