### PR TITLE
Appdata related paches

### DIFF
--- a/data/io.github.diegopvlk.Dosage.appdata.xml.in
+++ b/data/io.github.diegopvlk.Dosage.appdata.xml.in
@@ -4,7 +4,7 @@
 	<summary>Keep track of your treatments</summary>
 
 	<description>
-		<p>Medication tracker</p>
+		<p>Easily manage track treatments with Dosage: Notifications, History, Multiple Doses, Flexible Frequency, Customization, Stock Monitoring, and Duration Control</p>
 		<p>Features:</p>
 		<ul>
 			<li>Notifications — Get reminders at the right time</li>
@@ -18,10 +18,17 @@
 	</description>
 
 	<screenshots>
+		<screenshot type="default">
+			<caption>Dosage today window in light theme.</caption>
+			<image>https://raw.githubusercontent.com/diegopvlk/Dosage/main/screenshots/today-light.png</image>
+		</screenshot>
 		<screenshot>
-			<image>https://raw.githubusercontent.com/diegopvlk/Dosage/7cc03cc6a852d62e5ab8315712c598ef6c1f7a0e/screenshots/today-light.png</image>
-			<image>https://raw.githubusercontent.com/diegopvlk/Dosage/7cc03cc6a852d62e5ab8315712c598ef6c1f7a0e/screenshots/med-window-light.png</image>
-			<image>https://raw.githubusercontent.com/diegopvlk/Dosage/7cc03cc6a852d62e5ab8315712c598ef6c1f7a0e/screenshots/today-dark.png</image>
+			<caption>Dosage edit treatment window in light theme.</caption>
+			<image>https://raw.githubusercontent.com/diegopvlk/Dosage/main/screenshots/med-window-light.png</image>
+		</screenshot>
+		<screenshot>
+			<caption>Dosage today window in dark theme.</caption>
+			<image>https://raw.githubusercontent.com/diegopvlk/Dosage/main/screenshots/today-dark.png</image>
 		</screenshot>
 	</screenshots>
 
@@ -87,8 +94,27 @@
 	<project_license>GPL-3.0-only</project_license>
 	<developer_name translatable="no">Diego Povliuk</developer_name>
 	<update_contact>diego.pvlk@gmail.com</update_contact>
+	<launchable type="desktop-id">io.github.diegopvlk.Dosage.desktop</launchable>
+	<translation type="gettext">io.github.diegopvlk.Dosage</translation>
+    <keywords>
+		<keyword translate="no">dosage</keyword>
+		<keyword>medication</keyword>
+		<keyword>tracker</keyword>
+		<keyword>reminder</keyword>
+		<keyword>treatments</keyword>
+		<keyword>pill</keyword>
+		<keyword>drug</keyword>
+		<keyword>remedy</keyword>
+	</keywords>
+	<categories>
+		<category>GTK</category>
+		<category>GNOME</category>
+		<category>Utility</category>
+		<category>MedicalSoftware</category>
+		<category>Calendar</category>
+	</categories>
 	<url type="homepage">https://github.com/diegopvlk/Dosage</url>
 	<url type="bugtracker">https://github.com/diegopvlk/Dosage/issues</url>
 	<url type="vcs-browser">https://github.com/diegopvlk/Dosage</url>
-	<url type="translate">https://hosted.weblate.org/translate/dosage</url>
+	<url type="translate">https://hosted.weblate.org/projects/dosage/dosage/</url>
 </component>

--- a/data/io.github.diegopvlk.Dosage.desktop.in
+++ b/data/io.github.diegopvlk.Dosage.desktop.in
@@ -5,7 +5,7 @@ Exec=io.github.diegopvlk.Dosage
 Icon=io.github.diegopvlk.Dosage
 Terminal=false
 Type=Application
-Categories=GTK;GNOME;Utility;MedicalSoftware;History;Calendar;Database;
+Categories=GTK;GNOME;Utility;MedicalSoftware;Calendar;
 # TRANSLATORS: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-Keywords=Medication;Tracker;Reminder;Today;History;Treatments;Pill;Drug;Remedy;
+Keywords=Medication;Tracker;Reminder;Today;Treatments;Pill;Drug;Remedy;
 X-GNOME-UsesNotifications=true


### PR DESCRIPTION
### data: Remove two categories from the desktop file
- Dosage does not fit History and Database categories. 
More information: https://specifications.freedesktop.org/menu-spec/latest/apas02.html

### data: Update appdata

- Add related keywords
- Add related categories
- Update the translate URL
- Fix the appdata errors
- Update the first paragraph of the app description to fix appstreamcli warning

Validated with the following command:
```LC_ALL=C appstreamcli validate --explain data/io.github.diegopvlk.Dosage.appdata.xml.in```