### PR TITLE
data: use appstreamcli to validate appdata

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -42,9 +42,9 @@ appstream_file = i18n.merge_file(
 	install_dir: join_paths(get_option('datadir'), 'appdata')
 )
 
-appstream_util = find_program('appstream-util', required: false)
-if appstream_util.found()
-	test('Validate appstream file', appstream_util, args: ['validate', appstream_file])
+appstreamcli = find_program('appstreamcli', required: false)
+if appstreamcli.found()
+	test('Validate appstream file', appstreamcli, args: ['validate', '--no-net --explain', appstream_file])
 endif
 
 install_data('io.github.diegopvlk.Dosage.gschema.xml',


### PR DESCRIPTION
Use appstreamcli, not the older appstream-util to validate metadata.

More information: https://gitlab.gnome.org/World/eartag/-/merge_requests/95#note_1874726