### PR TITLE
appdata: Correct translation type file name

### DIFF
--- a/data/io.github.diegopvlk.Dosage.appdata.xml.in
+++ b/data/io.github.diegopvlk.Dosage.appdata.xml.in
@@ -116,7 +116,7 @@
 	<developer_name translatable="no">Diego Povliuk</developer_name>
 	<update_contact>diego.pvlk@gmail.com</update_contact>
 	<launchable type="desktop-id">io.github.diegopvlk.Dosage.desktop</launchable>
-	<translation type="gettext">io.github.diegopvlk.Dosage</translation>
+	<translation type="gettext">dosage</translation>
     <keywords>
 		<keyword translate="no">dosage</keyword>
 		<keyword>medication</keyword>


### PR DESCRIPTION
The real file name is "dosage".

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-translation