### PR TITLE
appdata: Remove categories

### DIFF
--- a/data/io.github.diegopvlk.Dosage.appdata.xml.in
+++ b/data/io.github.diegopvlk.Dosage.appdata.xml.in
@@ -9,23 +9,6 @@
 	<update_contact>diego.pvlk@gmail.com</update_contact>
 	<launchable type="desktop-id">io.github.diegopvlk.Dosage.desktop</launchable>
 	<translation type="gettext">dosage</translation>
-    <keywords>
-		<keyword translate="no">dosage</keyword>
-		<keyword>medication</keyword>
-		<keyword>tracker</keyword>
-		<keyword>reminder</keyword>
-		<keyword>treatments</keyword>
-		<keyword>pill</keyword>
-		<keyword>drug</keyword>
-		<keyword>remedy</keyword>
-	</keywords>
-	<categories>
-		<category>GTK</category>
-		<category>GNOME</category>
-		<category>Utility</category>
-		<category>MedicalSoftware</category>
-		<category>Calendar</category>
-	</categories>
 	<url type="homepage">https://github.com/diegopvlk/Dosage</url>
 	<url type="bugtracker">https://github.com/diegopvlk/Dosage/issues</url>
 	<url type="vcs-browser">https://github.com/diegopvlk/Dosage</url>


### PR DESCRIPTION
"Icons and categories

If there’s a type="desktop-id" launchable, they get pulled from it. Most of the icon not found errors with the flathub builder can be traced down to the launchable value not matching the desktop file name.

Don’t set them in the AppData unless you want to override them (even though then it might be a better idea to patch the desktop file itself)."

More information: https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/#icons-and-categories