### PR TITLE
snap: update for core24

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -1,0 +1,27 @@
+name: Build Dosage
+on:
+  push:
+    branches:
+      - main
+    tags-ignore:
+      - '**'
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  deploy-snap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Git repository
+        uses: actions/checkout@v4
+      - name: Build Snap
+        uses: snapcore/action-build@v1
+        id: snapcraft-build
+        env:
+          SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: 1
+        with:
+          snapcraft-args: "--verbosity debug"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dosage-snap
+          path: ${{ steps.snapcraft-build.outputs.snap }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dosage-tracker
-base: core22
+base: core24
 adopt-info: dosage-tracker
 grade: stable
 confinement: strict
@@ -21,7 +21,7 @@ parts:
     source-tag: "v1.6.1"
     build-environment:
       - PYTHONPATH: $CRAFT_STAGE/usr/lib/python3/dist-packages:$PYTHONPATH
-      - GI_TYPELIB_PATH: /snap/gnome-42-2204-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET/girepository-1.0:/snap/gnome-42-2204-sdk/current/usr/lib/girepository-1.0
+      - GI_TYPELIB_PATH: /snap/gnome-46-2404-sdk/current/usr/lib/girepository-1.0:/snap/gnome-46-2404-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET/girepository-1.0:/snap/gnome-46-2404-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET/gjs/girepository-1.0:$GI_TYPELIB_PATH
     meson-parameters:
       - --prefix=/snap/dosage-tracker/current/usr
     override-pull: |
@@ -46,7 +46,7 @@ apps:
     autostart: dosage-tracker-startup.desktop
     common-id: io.github.diegopvlk.Dosage
     environment:
-      GI_TYPELIB_PATH: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET/girepository-1.0:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET/gjs/girepository-1.0
+      GI_TYPELIB_PATH: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET/gjs/girepository-1.0:$GI_TYPELIB_PATH
     extensions:
       - gnome
     plugs:


### PR DESCRIPTION
Now we can add a github action also, to publish this snap, but only for `amd64` can't do the same for others