### PR TITLE
Move appstream metadata to the modern location.

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -50,7 +50,7 @@ appstream_file = i18n.merge_file(
 	output: 'io.github.diegopvlk.Dosage.appdata.xml',
 	po_dir: '../po',
 	install: true,
-	install_dir: join_paths(get_option('datadir'), 'appdata'),
+	install_dir: join_paths(get_option('datadir'), 'metainfo'),
 )
 
 appstreamcli = find_program('appstreamcli', required: false)


### PR DESCRIPTION
Appstream metadata was on legacy location (/usr/share/appdata). It should be moved to the modern location (/usr/share/metainfo).

https://wiki.debian.org/AppStream/Guidelines