### PR TITLE
chore: Add HealthFitness and Medication category

### DIFF
--- a/data/io.github.diegopvlk.Dosage.desktop.in
+++ b/data/io.github.diegopvlk.Dosage.desktop.in
@@ -5,7 +5,7 @@ Exec=io.github.diegopvlk.Dosage
 Icon=io.github.diegopvlk.Dosage
 Terminal=false
 Type=Application
-Categories=GTK;GNOME;Utility;MedicalSoftware;Calendar;
+Categories=GTK;GNOME;HealthFitness;Medication;Utility;MedicalSoftware;Calendar;
 # TRANSLATORS: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=Medication;Tracker;Reminder;Today;Treatments;Pill;Drug;Remedy;
 X-GNOME-UsesNotifications=true


### PR DESCRIPTION
HealthFitness and Medication were recently added as FreeDesktop categories.

You can find HealthFitness as a main category: https://specifications.freedesktop.org/menu/latest/category-registry.html
You can find Medication as an additional category: https://specifications.freedesktop.org/menu/latest/additional-category-registry.html