### PR TITLE
fix: sort by ended-last now moves ended treatments to bottom

### DIFF
--- a/src/treatmentsSorter.js
+++ b/src/treatmentsSorter.js
@@ -79,23 +79,16 @@ export function sortTreatFunc(sortingType) {
 			};
 		case 'ended-last':
 			return (a, b) => {
+				const isNeededA = a.obj.frequency === 'when-needed';
+				const isNeededB = b.obj.frequency === 'when-needed';
+
 				const durA = a.obj.duration;
 				const durB = b.obj.duration;
 
-				const enabledA = durA.enabled && a.obj.frequency !== 'when-needed';
-				const enabledB = durB.enabled && b.obj.frequency !== 'when-needed';
+				const isEndedA = !isNeededA && durA.enabled && new Date(durA.end).setHours(0, 0, 0, 0) < today;
+				const isEndedB = !isNeededB && durB.enabled && new Date(durB.end).setHours(0, 0, 0, 0) < today;
 
-				if (enabledA !== enabledB) return enabledB ? -1 : 1;
-
-				if (enabledA && enabledB) {
-					const endA = new Date(durA.end).setHours(0, 0, 0, 0);
-					const endB = new Date(durB.end).setHours(0, 0, 0, 0);
-
-					const pastA = endA < today;
-					const pastB = endB < today;
-
-					if (pastA !== pastB) return pastB ? 1 : -1;
-				}
+				if (isEndedA !== isEndedB) return isEndedB ? -1 : 1;
 
 				return a.obj.name.localeCompare(b.obj.name);
 			};


### PR DESCRIPTION
WIthout this patch, the "Ended Last" sort option moves all treatments with an end date (both ended and ongoing) to the bottom of the list. The ended treatments are erroneously sorted above any ongoing ones.

With this patch, the "Ended Last" sort option moves just the ended treatments to the bottom of the list.